### PR TITLE
ensure compilation of FastLAS2 on Arch Linux (#2)

### DIFF
--- a/FastLAS2/implementation/CMakeLists.txt
+++ b/FastLAS2/implementation/CMakeLists.txt
@@ -42,7 +42,7 @@ include_directories(${Boost_INCLUDE_DIRS})
 
 ADD_DEFINITIONS(
   -std=c++17
-  -o3
+  -O3
   #-g
 )
 

--- a/FastLAS2/implementation/RuleSchema.h
+++ b/FastLAS2/implementation/RuleSchema.h
@@ -28,6 +28,7 @@
 #include <set>
 #include <vector>
 #include <map>
+#include <string>
 
 /*
  * To optimise performance, these classes are designed to avoid duplicate


### PR DESCRIPTION
- change flag "-o3" to "-O3"
- add "#include <string>" to RuleSchema header
- issue #2 