### PR TITLE
[FEATURE] added flag to control number of numeric var assignments in sat suff stage

### DIFF
--- a/FastLAS2/implementation/Utils.cpp
+++ b/FastLAS2/implementation/Utils.cpp
@@ -51,6 +51,7 @@ namespace FastLAS {
   bool separate_abduction = false;
   bool categorical_contexts = false;
   bool any_cache = false;
+  int num_var_count = 1;
 
   vector<string> language({"f_triv___"});
 

--- a/FastLAS2/implementation/Utils.h
+++ b/FastLAS2/implementation/Utils.h
@@ -91,11 +91,13 @@ namespace FastLAS {
   extern bool force_safety;
   extern bool score_only;
   extern bool space_size;
+  extern int num_var_count;
   extern bool separate_abduction;
   extern bool any_cache;
   extern bool categorical_contexts;
   extern int sample_size, max_conditions;
   extern int timeout;
+  
 
   template<typename T, typename F> void parallel_exec(const T& jobs, int number_of_workers, F p) {
     std::queue<typename T::value_type> q;

--- a/FastLAS2/implementation/main.cpp
+++ b/FastLAS2/implementation/main.cpp
@@ -59,6 +59,7 @@ int main(int argc, char **argv) {
     ("nopl", "run the new phases of the FastNonOPL algorithm, needed for non-observational predicate learning.")
     ("opl", "do not run the new phases of the FastNonOPL algorithm, needed for non-observational predicate learning.")
     ("output-solve-program", "perform the main steps of the FastLAS algorithm, then write out the final ASP program used to search for an optimal solution.")
+    ("num-var-count", po::value<int>(), "number of numeric variable assignments allowed in search space.")
     ("file_names", po::value<vector<string>>(), "input files.")
     ("read-cache", po::value<string>(), "location to read cached data from.")
     ("write-cache", po::value<string>(), "location to write cached data to.")
@@ -115,6 +116,7 @@ int main(int argc, char **argv) {
   if(vm.count("opl")) FastLAS::run_fast_las_2 = false;
   if(vm.count("force-safety")) FastLAS::force_safety = true;
   if(vm.count("score-only")) FastLAS::score_only = true;
+  if(vm.count("num-var-count")) FastLAS::num_var_count = vm["num-var-count"].as<int>();
 
   // parse
 

--- a/FastLAS2/implementation/stages/SatSuff.cpp
+++ b/FastLAS2/implementation/stages/SatSuff.cpp
@@ -120,7 +120,11 @@ void FastLAS::compute_sat_sufficient() {
     for(int i = 0; i < bias->maxv; i++)       ss << "var(v_a_r" << i << ")." << endl;
 
     ss << meta_sat_suff;
-    ss << "numeric_var(n_v_a_r_0)." << endl;
+
+    for(int i = 0; i<FastLAS::num_var_count; i++){
+      ss << "numeric_var(n_v_a_r_"<< i <<")." << endl;
+    }
+
 
     if(bias->gwr) {
       ss << R"(


### PR DESCRIPTION
- Added flag in main.cpp num-var-count <int> i.e. FastLAS --num-var-count 4
- Updated utils to add int FastLAS::num_var_count
- Updated satsuff.cpp to loop through and add the number of numeric variable assignments given through the flag